### PR TITLE
Problem with selection of MEG sensors in 'oat_run_first_level_epoched' when using an Elekta Triux System and generation of too much figures when running TF analysis

### DIFF
--- a/cluster4d_batch.m
+++ b/cluster4d_batch.m
@@ -74,7 +74,7 @@ for r = 1:nP/100;
         permdir = sprintf('%s/%s/%04.0f',dirname,subdirname,t);
         for p = 1:100;
             if fsl_version_4p1
-                fprintf(fid,['cluster -i %s/stats%04.0f_rawstat_tstat1_%05.0f -t %1.2f -o %s/cindex%05.0f; '],...
+                fprintf(fid,['cluster -i %s/stats%04.0f_clustere_tstat1_perm%05.0f -t %1.2f -o %s/cindex%05.0f; '],... %Lars
                     permdir,t,p,thresh,permdir,(r-1)*100+p); % -c means cluster-based thresholding
             else
                 fprintf(fid,['cluster -i %s/stats%04.0f_vox_tstat1_perm%05.0f -t %1.2f -o %s/cindex%05.0f; '],...
@@ -92,7 +92,7 @@ for r = 1:nP/100;
         fprintf(fid,'rm ');
         for p = 1:100
             if fsl_version_4p1
-                fprintf(fid,'%s/stats%04.0f_rawstat_tstat1_%05.0f.nii.gz ',permdir,t,p);
+                fprintf(fid,'%s/stats%04.0f_clustere_tstat1_perm%05.0f.nii.gz ',permdir,t,p);
             else
                 fprintf(fid,'%s/stats%04.0f_*_tstat1_perm%05.0f.nii.gz ',permdir,t,p);
             end;
@@ -129,13 +129,15 @@ for r = 1:nP/fsl_sub_rsize;
     fprintf(fid,['addpath(''%s'');\n addpath(''%s/etc/matlab'');\n' ...
         'S.dirname = ''%s''; S.subdirname = ''%s''; S.distfile_save = ''%s''; S.np = %0.0f:%0.0f;'],...
         tmp(1:end-17),getenv('FSLDIR'),dirname,subdirname,distfile_save,(r-1)*fsl_sub_rsize+1,r*fsl_sub_rsize);
+    fprintf(fid,['addpath(''%sohba-external/ohba_utils'');'], tmp(1:end-25));
+    fprintf(fid,['addpath(''%sohba-external/nifti_tools'');'], tmp(1:end-25));
     fprintf(fid,['S.tp = ',mat2str(tp) ';']);
     fprintf(fid,['S.times = ',mat2str(times) ';']);
-    fprintf(fid,'S.save_images = 0;\n S.gridstep = %0.0f; \n cluster4d_dist(S);',gridstep);
+    fprintf(fid,'S.save_images = 1;\n S.gridstep = %0.0f; \n cluster4d_dist(S);',gridstep); 
     fclose(fid);
 
     if(~write_cluster_script),
-        fprintf(fidM,'%s -nojvm -nodisplay -nosplash -singleCompThread \\< %s \n',S.matlab_exe_name,mfile);
+        fprintf(fidM,'%s -nodisplay -nosplash -singleCompThread \\< %s \n',S.matlab_exe_name,mfile);
     else,
         fprintf(fidM,'jid4=`fsl_sub -q long.q -j $jid3 -l %s %s -nojvm -nodisplay -nosplash -singleCompThread \\< %s > %s/log_cluster4d_dist.log  2>&1` \n',lfname,S.matlab_exe_name,mfile,lfname);
     end;
@@ -166,7 +168,8 @@ fprintf(fid,['save(''' distfile_save ''', ''-struct'', ''clusterstats'');']);
 fclose(fid);
     
 if(~write_cluster_script),
-    fprintf(fidM,'%s -nojvm -nodisplay -nosplash -singleCompThread \\< %s \n',S.matlab_exe_name,mfile);
+    fprintf(fidM,'%s -nodisplay -nosplash -singleCompThread \\< %s \n',S.matlab_exe_name,mfile);
+    
 else,
     fprintf(fidM,'fsl_sub -q long.q -j $jid4 -l %s %s -nojvm -nodisplay -nosplash -singleCompThread \\< %s > %s/log_cluster4d_dist.log  2>&1 \n',lfname,S.matlab_exe_name,mfile,lfname);
 end;

--- a/cluster4d_dist.m
+++ b/cluster4d_dist.m
@@ -126,9 +126,10 @@ if save_images
     clustimg_fname = [dirname '/clust4d.nii.gz'];
     pVimg_fname = [dirname '/clust4d_corrp.nii.gz'];
     
+    xform = [-gridstep 0 0 90; 0 gridstep 0 -126; 0 0 gridstep -72; 0 0 0 1]; 
     tres=1;
-    nii.save(clustimg,[gridstep gridstep gridstep tres],[],clustimg_fname);
-    nii.save(pVimg,[gridstep gridstep gridstep tres],[],pVimg_fname);
+    nii.save(clustimg,[gridstep gridstep gridstep tres],xform,clustimg_fname);
+    nii.save(pVimg,[gridstep gridstep gridstep tres],xform,pVimg_fname);
     
 end
 

--- a/oat/oat_cluster_permutation_testing.m
+++ b/oat/oat_cluster_permutation_testing.m
@@ -224,6 +224,8 @@ for coni=1:length(S.first_level_copes_to_do),
             Sb.matlab_exe_name=S.matlab_exe_name;
             gstats.clusterstats{con,gcon}=cluster4d_batch(Sb);
             
+            gstats.dir=Sb.dirname;
+            
             disp('Saving cluster stats.');
             
             oat_save_results(S.oat,gstats);

--- a/oat/oat_first_level_stats_report.m
+++ b/oat/oat_first_level_stats_report.m
@@ -271,6 +271,6 @@ end;
 report=osl_report_write(report);
 disp(['View first level report at:']);
 disp([report.html_fname]);
-
+close all
 end
 

--- a/oat/oat_run_first_level_epoched.m
+++ b/oat/oat_run_first_level_epoched.m
@@ -140,7 +140,7 @@ for subi_todo=1:length(first_level.sessions_to_do),
             first_level_results.chanlabels=D.chanlabels(chanindmeg);
             first_level_results.chantype=D.chantype(chanindmeg);
 
-            first_level_results.mask_indices_in_source_recon=1:length(chanindmeg);
+            first_level_results.mask_indices_in_source_recon=chanindmeg;
 
         else,
 


### PR DESCRIPTION
In an Elekta Triux system (compared to e.g. Neuromag) the first 14 channels are EOG ECG IASX+ … IAS_Z and channels 15-321 are the sensors. Line 141 correctly puts the MEGMAG and MEGPLANAR channel indices in 'chanindmeg' but then selects channels using '1:length(chanindmeg)' instead of 'chanindmeg', causing channels 1:306 to be selected instead of 15:321.

The second commit relates to Java errors caused by the production of an abundance of figures without closing them when running a time-frequency analysis.