### PR TITLE
Removed hard fail if events in .fif/.ds files are non-numeric

### DIFF
--- a/osl_import.m
+++ b/osl_import.m
@@ -79,8 +79,12 @@ function D = osl_import(raw_data,varargin)
     %% MWW added back in from osl1.2.beta.15 - Oct 2013
     ev = events(D,1);
     for j = 1:length(ev)
-        if isempty(ev(j).value) || ~(ev(j).value>0)
-            ev(j).value=1;
+        try
+            if isempty(ev(j).value) || ~(ev(j).value>0)
+                ev(j).value=1;
+            end
+        catch
+            warning('Strange event type encountered in the raw data object. Please inspect the events in the raw file!');
         end
     end
     D = D.events(1,ev);


### PR DESCRIPTION
osl_import will now through a warning message to the user in case an event (which is normally numeric) contains text. A common instance of this is if the raw .fif/.ds file contains events which are marked with "BAD". The rest of the events are read in as normal, and the event which contains a string is ignored.